### PR TITLE
Add chrome mobile appBar color support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ url: 'http://webjeda.com'
 baseurl: '/online-cv' #change it according to your repository name
 # Style will be applied only after restarting the build or serve. Just choose one of the options.
 theme_skin: blue # blue turquoise green berry orange ceramic
+chrome_mobile_color: #use hex colors (ex:#1976d2) or leave empty if you don't want a color for chrome mobile searchbar
 
 # Tracker
 analytics: UA-83979019-1

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,9 @@
 
   <!-- Meta -->
   <meta charset="utf-8">
+  {% if site.chrome_mobile_color %}
+  <meta name="theme-color" content="{{ site.chrome_mobile_color }}">
+  {% endif%}
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="A beautiful Jekyll theme for creating resume">


### PR DESCRIPTION
# Support for chrome mobile appBar.

Here is an example :

![image](https://user-images.githubusercontent.com/29121316/47604876-79506580-d9ff-11e8-9198-506f6c26227a.png)

To see more : https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android